### PR TITLE
Many to Many Association - Struct definition

### DIFF
--- a/association_test.go
+++ b/association_test.go
@@ -144,11 +144,11 @@ func TestAssociation_Document(t *testing.T) {
 
 func TestAssociation_Collection(t *testing.T) {
 	var (
-		transaction  = &Transaction{ID: 1}
-		user         = &User{ID: 2}
-		address      = &Address{ID: 3}
-		subscription = &Subscription{ID: 4}
-		userLoaded   = &User{
+		transaction = &Transaction{ID: 1}
+		user        = &User{ID: 2}
+		address     = &Address{ID: 3}
+		role        = &Role{ID: 4}
+		userLoaded  = &User{
 			ID: 2, Address: *address,
 			Transactions: []Transaction{*transaction},
 		}
@@ -198,35 +198,35 @@ func TestAssociation_Collection(t *testing.T) {
 		},
 		{
 			record:           "User",
-			field:            "Subscriptions",
+			field:            "Roles",
 			data:             user,
 			typ:              ManyToMany,
-			col:              NewCollection(&user.Subscriptions),
+			col:              NewCollection(&user.Roles),
 			loaded:           false,
 			isZero:           true,
 			referenceField:   "id",
 			referenceThrough: "user_id",
 			referenceValue:   user.ID,
 			foreignField:     "id",
-			foreignThrough:   "subscription_id",
+			foreignThrough:   "role_id",
 			foreignValue:     nil,
-			through:          "subscription_users",
+			through:          "user_roles",
 		},
 		{
-			record:           "Subscription",
+			record:           "Role",
 			field:            "Users",
-			data:             subscription,
+			data:             role,
 			typ:              ManyToMany,
-			col:              NewCollection(&subscription.Users),
+			col:              NewCollection(&role.Users),
 			loaded:           false,
 			isZero:           true,
 			referenceField:   "id",
-			referenceThrough: "subscription_id",
-			referenceValue:   subscription.ID,
+			referenceThrough: "role_id",
+			referenceValue:   role.ID,
 			foreignField:     "id",
 			foreignThrough:   "user_id",
 			foreignValue:     nil,
-			through:          "subscription_users",
+			through:          "user_roles",
 		},
 		{
 			record:           "User",

--- a/rel_test.go
+++ b/rel_test.go
@@ -13,8 +13,18 @@ type User struct {
 	Transactions []Transaction `ref:"id" fk:"user_id"`
 	Address      Address
 	UserRoles    []UserRole
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+
+	// many to many
+	// user:id <- user_id:subscription_users:subscription_id -> subscriptions:id
+	Subscriptions []Subscription `through:"subscription_users"`
+
+	// many to many: self-referencing with explicitly defined ref and fk.
+	// omit mapped field.
+	Followers  []User `ref:"id:following_id" fk:"id:follower_id" through:"followers"`
+	Followings []User `ref:"id:follower_id" fk:"id:following_id" through:"followers"`
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 type Transaction struct {
@@ -66,4 +76,13 @@ type Role struct {
 type UserRole struct {
 	UserID int `db:",primary"`
 	RoleID int `db:",primary"`
+}
+
+type Subscription struct {
+	ID   int
+	Name string
+
+	// basic many to many declaration:
+	// subscription:id <- subscription_id:subscription_users:user_id -> user:id
+	Users []User `ref:"id:subscription_id" fk:"id:user_id" through:"subscription_users"`
 }

--- a/rel_test.go
+++ b/rel_test.go
@@ -15,8 +15,8 @@ type User struct {
 	UserRoles    []UserRole
 
 	// many to many
-	// user:id <- user_id:subscription_users:subscription_id -> subscriptions:id
-	Subscriptions []Subscription `through:"subscription_users"`
+	// user:id <- user_id:user_roles:role_id -> role:id
+	Roles []Role `through:"user_roles"`
 
 	// many to many: self-referencing with explicitly defined ref and fk.
 	// omit mapped field.
@@ -71,18 +71,13 @@ type Role struct {
 	ID        int
 	Name      string
 	UserRoles []UserRole
+
+	// explicit many to many declaration:
+	// role:id <- role_id:user_roles:user_id -> user:id
+	Users []User `ref:"id:role_id" fk:"id:user_id" through:"user_roles"`
 }
 
 type UserRole struct {
 	UserID int `db:",primary"`
 	RoleID int `db:",primary"`
-}
-
-type Subscription struct {
-	ID   int
-	Name string
-
-	// basic many to many declaration:
-	// subscription:id <- subscription_id:subscription_users:user_id -> user:id
-	Users []User `ref:"id:subscription_id" fk:"id:user_id" through:"subscription_users"`
 }


### PR DESCRIPTION
- This PR introduce `through` tag for many to many association.
- Also added support for handling explicit many to many mapping with `ref` and `fk` field tag.

#104 