### PR TITLE
Improve test coverage and edge cases bug fix

### DIFF
--- a/changeset.go
+++ b/changeset.go
@@ -1,6 +1,7 @@
 package rel
 
 import (
+	"bytes"
 	"reflect"
 	"time"
 )
@@ -26,7 +27,11 @@ func (c Changeset) valueChanged(typ reflect.Type, old interface{}, new interface
 		return !ot.Equal(new.(time.Time))
 	}
 
-	return !(typ.Comparable() && old == new)
+	if typ.Comparable() {
+		return old != new
+	}
+
+	return bytes.Compare(reflect.ValueOf(old).Bytes(), reflect.ValueOf(new).Bytes()) != 0
 }
 
 // FieldChanged returns true if field exists and it's already changed.

--- a/rel_test.go
+++ b/rel_test.go
@@ -1,10 +1,19 @@
 package rel
 
 import (
+	"encoding/json"
 	"time"
 )
 
 type Status string
+
+type extendedUser struct {
+	ID        int
+	Password  []byte
+	Metadata  json.RawMessage
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
 
 type User struct {
 	ID           int


### PR DESCRIPTION
changeset fails on comparing byte slices e.g. `json.RawMessage`