### PR TITLE
Support BigID Column Builder

### DIFF
--- a/adapter/mysql/mysql_test.go
+++ b/adapter/mysql/mysql_test.go
@@ -1,3 +1,5 @@
+// +build all mysql
+
 package mysql
 
 import (

--- a/adapter/mysql/mysql_test.go
+++ b/adapter/mysql/mysql_test.go
@@ -1,5 +1,3 @@
-// +build all mysql
-
 package mysql
 
 import (

--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -167,6 +167,8 @@ func mapColumnFunc(column *rel.Column) (string, int, int) {
 	switch column.Type {
 	case rel.ID:
 		typ = "SERIAL NOT NULL PRIMARY KEY"
+	case rel.BigID:
+		typ = "BIGSERIAL NOT NULL PRIMARY KEY"
 	case rel.DateTime:
 		typ = "TIMESTAMPTZ"
 		if t, ok := column.Default.(time.Time); ok {

--- a/adapter/specs/migration.go
+++ b/adapter/specs/migration.go
@@ -98,7 +98,7 @@ func Migrate(t *testing.T, repo rel.Repository, flags ...Flag) {
 	m.Register(5,
 		func(schema *rel.Schema) {
 			schema.CreateTable("dummies", func(t *rel.Table) {
-				t.ID("id")
+				t.BigID("id")
 				t.Bool("bool1")
 				t.Bool("bool2", rel.Default(true))
 				t.Int("int1")

--- a/adapter/sql/builder_test.go
+++ b/adapter/sql/builder_test.go
@@ -84,13 +84,13 @@ func TestBuilder_Table(t *testing.T) {
 			},
 		},
 		{
-			result: "CREATE TABLE IF NOT EXISTS `products` (`id` INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, `raw` BOOL);",
+			result: "CREATE TABLE IF NOT EXISTS `products` (`id` BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, `raw` BOOL);",
 			table: rel.Table{
 				Op:       rel.SchemaCreate,
 				Name:     "products",
 				Optional: true,
 				Definitions: []rel.TableDefinition{
-					rel.Column{Name: "id", Type: rel.ID},
+					rel.Column{Name: "id", Type: rel.BigID},
 					rel.Raw("`raw` BOOL"),
 				},
 			},

--- a/adapter/sql/config.go
+++ b/adapter/sql/config.go
@@ -30,6 +30,8 @@ func MapColumn(column *rel.Column) (string, int, int) {
 	switch column.Type {
 	case rel.ID:
 		typ = "INT UNSIGNED AUTO_INCREMENT PRIMARY KEY"
+	case rel.BigID:
+		typ = "BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY"
 	case rel.Bool:
 		typ = "BOOL"
 	case rel.Int:

--- a/adapter/sqlite3/sqlite3.go
+++ b/adapter/sqlite3/sqlite3.go
@@ -106,6 +106,8 @@ func mapColumnFunc(column *rel.Column) (string, int, int) {
 	switch column.Type {
 	case rel.ID:
 		typ = "INTEGER PRIMARY KEY"
+	case rel.BigID:
+		typ = "BIGINT PRIMARY KEY"
 	case rel.Int:
 		typ = "INTEGER"
 		m = column.Limit

--- a/column.go
+++ b/column.go
@@ -6,6 +6,8 @@ type ColumnType string
 const (
 	// ID ColumnType.
 	ID ColumnType = "ID"
+	// BigID ColumnType.
+	BigID ColumnType = "BigID"
 	// Bool ColumnType.
 	Bool ColumnType = "BOOL"
 	// SmallInt ColumnType.

--- a/table.go
+++ b/table.go
@@ -26,6 +26,12 @@ func (t *Table) ID(name string, options ...ColumnOption) {
 	t.Column(name, ID, options...)
 }
 
+// BigID defines a column with name and Big ID type.
+// the resulting database type will depends on database.
+func (t *Table) BigID(name string, options ...ColumnOption) {
+	t.Column(name, BigID, options...)
+}
+
 // Bool defines a column with name and Bool type.
 func (t *Table) Bool(name string, options ...ColumnOption) {
 	t.Column(name, Bool, options...)

--- a/table_test.go
+++ b/table_test.go
@@ -17,6 +17,22 @@ func TestTable(t *testing.T) {
 		}, table.Definitions[len(table.Definitions)-1])
 	})
 
+	t.Run("ID", func(t *testing.T) {
+		table.ID("id")
+		assert.Equal(t, Column{
+			Name: "id",
+			Type: ID,
+		}, table.Definitions[len(table.Definitions)-1])
+	})
+
+	t.Run("BigID", func(t *testing.T) {
+		table.BigID("big_id")
+		assert.Equal(t, Column{
+			Name: "big_id",
+			Type: BigID,
+		}, table.Definitions[len(table.Definitions)-1])
+	})
+
 	t.Run("Bool", func(t *testing.T) {
 		table.Bool("boolean")
 		assert.Equal(t, Column{


### PR DESCRIPTION
> rel.ID is interesting. It mixes in a few different things. It would be interesting to have a rel.BigID that maps to BIGINT NOT NULL IDENTITY(1,1) PRIMARY KEY

https://github.com/go-rel/mssql/issues/9