### PR TITLE
Deprecate Timestamp Column Builder

### DIFF
--- a/column.go
+++ b/column.go
@@ -31,6 +31,8 @@ const (
 	// Time ColumnType.
 	Time ColumnType = "TIME"
 	// Timestamp ColumnType.
+	//
+	// Deprecated: builder for this column type is deprecated, because incompatibility of different databases.
 	Timestamp ColumnType = "TIMESTAMP"
 )
 

--- a/table.go
+++ b/table.go
@@ -88,6 +88,8 @@ func (t *Table) Time(name string, options ...ColumnOption) {
 }
 
 // Timestamp defines a column with name and Timestamp type.
+//
+// Deprecated: builder for this column type is deprecated, because incompatibility of different databases.
 func (t *Table) Timestamp(name string, options ...ColumnOption) {
 	t.Column(name, Timestamp, options...)
 }


### PR DESCRIPTION
Different database have different definition for timestamp (at least they are far from 100% compatible), alternative for this is to use Date, DateTime or Time, or define it using raw column builder (`t.Column("ts", "timestamp")`).

Related: https://github.com/go-rel/mssql/issues/8