### PR TITLE
Remove timestamp from schema migration builder

### DIFF
--- a/adapter/specs/migration.go
+++ b/adapter/specs/migration.go
@@ -119,7 +119,6 @@ func Migrate(t *testing.T, repo rel.Repository, flags ...Flag) {
 				t.DateTime("datetime2", rel.Default(time.Now()))
 				t.Time("time1")
 				t.Time("time2", rel.Default(time.Now()))
-				t.Timestamp("timestamp1")
 
 				t.Unique([]string{"int2"})
 				t.Unique([]string{"bigint1", "bigint2"})

--- a/adapter/sql/builder_test.go
+++ b/adapter/sql/builder_test.go
@@ -59,7 +59,7 @@ func TestBuilder_Table(t *testing.T) {
 			},
 		},
 		{
-			result: "CREATE TABLE `columns` (`bool` BOOL NOT NULL DEFAULT false, `int` INT(11) UNSIGNED, `bigint` BIGINT(20) UNSIGNED, `float` FLOAT(24) UNSIGNED, `decimal` DECIMAL(6,2) UNSIGNED, `string` VARCHAR(144) UNIQUE, `text` TEXT(1000), `date` DATE, `datetime` DATETIME DEFAULT '2020-01-01 01:00:00', `blob` blob, PRIMARY KEY (`int`), FOREIGN KEY (`int`, `string`) REFERENCES `products` (`id`, `name`) ON DELETE CASCADE ON UPDATE CASCADE, UNIQUE `date_unique` (`date`)) Engine=InnoDB;",
+			result: "CREATE TABLE `columns` (`bool` BOOL NOT NULL DEFAULT false, `int` INT(11) UNSIGNED, `bigint` BIGINT(20) UNSIGNED, `float` FLOAT(24) UNSIGNED, `decimal` DECIMAL(6,2) UNSIGNED, `string` VARCHAR(144) UNIQUE, `text` TEXT(1000), `date` DATE, `datetime` DATETIME DEFAULT '2020-01-01 01:00:00', `time` TIME, `blob` blob, PRIMARY KEY (`int`), FOREIGN KEY (`int`, `string`) REFERENCES `products` (`id`, `name`) ON DELETE CASCADE ON UPDATE CASCADE, UNIQUE `date_unique` (`date`)) Engine=InnoDB;",
 			table: rel.Table{
 				Op:   rel.SchemaCreate,
 				Name: "columns",
@@ -72,8 +72,8 @@ func TestBuilder_Table(t *testing.T) {
 					rel.Column{Name: "string", Type: rel.String, Limit: 144, Unique: true},
 					rel.Column{Name: "text", Type: rel.Text, Limit: 1000},
 					rel.Column{Name: "date", Type: rel.Date},
-					rel.Column{Name: "datetime", Type: rel.DateTime},
-					rel.Column{Name: "time", Type: rel.Time, Default: time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)},
+					rel.Column{Name: "datetime", Type: rel.DateTime, Default: time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)},
+					rel.Column{Name: "time", Type: rel.Time},
 					rel.Column{Name: "blob", Type: "blob"},
 					rel.Key{Columns: []string{"int"}, Type: rel.PrimaryKey},
 					rel.Key{Columns: []string{"int", "string"}, Type: rel.ForeignKey, Reference: rel.ForeignKeyReference{Table: "products", Columns: []string{"id", "name"}, OnDelete: "CASCADE", OnUpdate: "CASCADE"}},

--- a/adapter/sql/builder_test.go
+++ b/adapter/sql/builder_test.go
@@ -59,7 +59,7 @@ func TestBuilder_Table(t *testing.T) {
 			},
 		},
 		{
-			result: "CREATE TABLE `columns` (`bool` BOOL NOT NULL DEFAULT false, `int` INT(11) UNSIGNED, `bigint` BIGINT(20) UNSIGNED, `float` FLOAT(24) UNSIGNED, `decimal` DECIMAL(6,2) UNSIGNED, `string` VARCHAR(144) UNIQUE, `text` TEXT(1000), `date` DATE, `datetime` DATETIME, `time` TIME, `timestamp` TIMESTAMP DEFAULT '2020-01-01 01:00:00', `blob` blob, PRIMARY KEY (`int`), FOREIGN KEY (`int`, `string`) REFERENCES `products` (`id`, `name`) ON DELETE CASCADE ON UPDATE CASCADE, UNIQUE `date_unique` (`date`)) Engine=InnoDB;",
+			result: "CREATE TABLE `columns` (`bool` BOOL NOT NULL DEFAULT false, `int` INT(11) UNSIGNED, `bigint` BIGINT(20) UNSIGNED, `float` FLOAT(24) UNSIGNED, `decimal` DECIMAL(6,2) UNSIGNED, `string` VARCHAR(144) UNIQUE, `text` TEXT(1000), `date` DATE, `datetime` DATETIME DEFAULT '2020-01-01 01:00:00', `blob` blob, PRIMARY KEY (`int`), FOREIGN KEY (`int`, `string`) REFERENCES `products` (`id`, `name`) ON DELETE CASCADE ON UPDATE CASCADE, UNIQUE `date_unique` (`date`)) Engine=InnoDB;",
 			table: rel.Table{
 				Op:   rel.SchemaCreate,
 				Name: "columns",
@@ -73,8 +73,7 @@ func TestBuilder_Table(t *testing.T) {
 					rel.Column{Name: "text", Type: rel.Text, Limit: 1000},
 					rel.Column{Name: "date", Type: rel.Date},
 					rel.Column{Name: "datetime", Type: rel.DateTime},
-					rel.Column{Name: "time", Type: rel.Time},
-					rel.Column{Name: "timestamp", Type: rel.Timestamp, Default: time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)},
+					rel.Column{Name: "time", Type: rel.Time, Default: time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)},
 					rel.Column{Name: "blob", Type: "blob"},
 					rel.Key{Columns: []string{"int"}, Type: rel.PrimaryKey},
 					rel.Key{Columns: []string{"int", "string"}, Type: rel.ForeignKey, Reference: rel.ForeignKeyReference{Table: "products", Columns: []string{"id", "name"}, OnDelete: "CASCADE", OnUpdate: "CASCADE"}},

--- a/adapter/sql/config.go
+++ b/adapter/sql/config.go
@@ -64,8 +64,6 @@ func MapColumn(column *rel.Column) (string, int, int) {
 	case rel.Time:
 		typ = "TIME"
 		timeLayout = "15:04:05"
-	case rel.Timestamp:
-		typ = "TIMESTAMP"
 	default:
 		typ = string(column.Type)
 	}

--- a/column.go
+++ b/column.go
@@ -30,10 +30,6 @@ const (
 	DateTime ColumnType = "DATETIME"
 	// Time ColumnType.
 	Time ColumnType = "TIME"
-	// Timestamp ColumnType.
-	//
-	// Deprecated: builder for this column type is deprecated, because incompatibility of different databases.
-	Timestamp ColumnType = "TIMESTAMP"
 )
 
 // Column definition.

--- a/table.go
+++ b/table.go
@@ -87,13 +87,6 @@ func (t *Table) Time(name string, options ...ColumnOption) {
 	t.Column(name, Time, options...)
 }
 
-// Timestamp defines a column with name and Timestamp type.
-//
-// Deprecated: builder for this column type is deprecated, because incompatibility of different databases.
-func (t *Table) Timestamp(name string, options ...ColumnOption) {
-	t.Column(name, Timestamp, options...)
-}
-
 // PrimaryKey defines a primary key for table.
 func (t *Table) PrimaryKey(column string, options ...KeyOption) {
 	t.PrimaryKeys([]string{column}, options...)

--- a/table_test.go
+++ b/table_test.go
@@ -121,14 +121,6 @@ func TestTable(t *testing.T) {
 		}, table.Definitions[len(table.Definitions)-1])
 	})
 
-	t.Run("Timestamp", func(t *testing.T) {
-		table.Timestamp("timestamp")
-		assert.Equal(t, Column{
-			Name: "timestamp",
-			Type: Timestamp,
-		}, table.Definitions[len(table.Definitions)-1])
-	})
-
 	t.Run("PrimaryKey", func(t *testing.T) {
 		table.PrimaryKey("id")
 		assert.Equal(t, Key{


### PR DESCRIPTION
Different database have different definition for timestamp (at least they are far from 100% compatible), alternative for this is to use Date, DateTime or Time, or define it using raw column builder (t.Column("ts", "timestamp")).

Deprecated at: https://github.com/go-rel/rel/pull/156