### PR TITLE
Use text/template instead html/template

### DIFF
--- a/cmd/rel/internal/migrate.go
+++ b/cmd/rel/internal/migrate.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"html/template"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"text/template"
 
 	"github.com/serenize/snaker"
 )


### PR DESCRIPTION
Using `text/template` instead `html/template` allows the usage of special characters in a dsn.

template documentation: https://golang.org/pkg/html/template/
```
HTML templates treat data values as plain text which should be encoded so they can be safely embedded in an HTML document. The escaping is contextual, so actions can appear within JavaScript, CSS, and URI contexts.
```

Without this fix, special characters in a dsn string like `&` (for example `&parseTime=true`) would be escaped as `&amp;`.

This should fix: #165 