### PR TITLE
Update association only if primary and foreign keys are set

### DIFF
--- a/cmd/rel/internal/migrate.go
+++ b/cmd/rel/internal/migrate.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"html/template"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"text/template"
 
 	"github.com/serenize/snaker"
 )

--- a/repository.go
+++ b/repository.go
@@ -666,10 +666,10 @@ func (r repository) saveHasMany(cw contextWrapper, doc *Document, mutation *Muta
 
 			// When deleted IDs is nil, it's assumed that association will be replaced.
 			// hence any update request is ignored here.
-			if deletedIDs != nil && !isZero(assocDoc.PrimaryValue()) {
+			var fValue, _ = assocDoc.Value(fField)
+			if deletedIDs != nil && !isZero(assocDoc.PrimaryValue()) && !isZero(fValue) {
 				var (
-					fValue, _ = assocDoc.Value(fField)
-					filter    = filterDocument(assocDoc).AndEq(fField, rValue)
+					filter = filterDocument(assocDoc).AndEq(fField, rValue)
 				)
 
 				if rValue != fValue {


### PR DESCRIPTION
If you have entities whose primary key value is not automatically generated (for example a UUID), the repository should be able to insert a new association on `repository.Update()`. To insert a new association, one of the keys (primary or foreign) must be zero. If both keys are set, the association should be updated.