### PR TITLE
Allow to insert association with predefined primary keys

### DIFF
--- a/cmd/rel/internal/migrate.go
+++ b/cmd/rel/internal/migrate.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"html/template"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"text/template"
 
 	"github.com/serenize/snaker"
 )

--- a/repository.go
+++ b/repository.go
@@ -586,7 +586,8 @@ func (r repository) saveHasOne(cw contextWrapper, doc *Document, mutation *Mutat
 			assocMut         = assocMuts.Mutations[0]
 		)
 
-		if loaded {
+		if loaded && ("" == assoc.ForeignField() ||
+			("" != assoc.ForeignField() && nil != assoc.ForeignValue())) {
 			filter, err := filterHasOne(assoc, assocDoc)
 			if err != nil {
 				return err

--- a/repository.go
+++ b/repository.go
@@ -587,7 +587,7 @@ func (r repository) saveHasOne(cw contextWrapper, doc *Document, mutation *Mutat
 		)
 
 		if loaded && ("" == assoc.ForeignField() ||
-			("" != assoc.ForeignField() && nil != assoc.ForeignValue())) {
+			("" != assoc.ForeignField() && !isZero(assoc.ForeignValue()))) {
 			filter, err := filterHasOne(assoc, assocDoc)
 			if err != nil {
 				return err

--- a/repository.go
+++ b/repository.go
@@ -666,10 +666,10 @@ func (r repository) saveHasMany(cw contextWrapper, doc *Document, mutation *Muta
 
 			// When deleted IDs is nil, it's assumed that association will be replaced.
 			// hence any update request is ignored here.
-			if deletedIDs != nil && !isZero(assocDoc.PrimaryValue()) {
+			var fValue, _ = assocDoc.Value(fField)
+			if deletedIDs != nil && !isZero(assocDoc.PrimaryValue()) && !isZero(fValue) {
 				var (
-					fValue, _ = assocDoc.Value(fField)
-					filter    = filterDocument(assocDoc).AndEq(fField, rValue)
+					filter = filterDocument(assocDoc).AndEq(fField, rValue)
 				)
 
 				if rValue != fValue {

--- a/repository.go
+++ b/repository.go
@@ -586,8 +586,7 @@ func (r repository) saveHasOne(cw contextWrapper, doc *Document, mutation *Mutat
 			assocMut         = assocMuts.Mutations[0]
 		)
 
-		if loaded && ("" == assoc.ForeignField() ||
-			("" != assoc.ForeignField() && !isZero(assoc.ForeignValue()))) {
+		if loaded && (assoc.ForeignField() == "" || !isZero(assoc.ForeignValue())) {
 			filter, err := filterHasOne(assoc, assocDoc)
 			if err != nil {
 				return err

--- a/repository_test.go
+++ b/repository_test.go
@@ -1916,8 +1916,9 @@ func TestRepository_saveHasOne_updateInconsistentAssoc(t *testing.T) {
 		mutation = Apply(doc,
 			Map{
 				"address": Map{
-					"id":     2,
-					"street": "street1",
+					"id":      2,
+					"user_id": 2,
+					"street":  "street1",
 				},
 			},
 		)


### PR DESCRIPTION
If you have entities with predefined primary keys (e.g. UUID), then it should be possible to create this association on insert.

Check if an entity has a foreign key and if the foreign key value is zero, then insert a new row into the database. If the primary and the foreign key are set, update the given row.
If an entity has no foreign key, then check if the primary key is set or not.

Without this code change, it is not possible to insert the following struct:
```go
type A struct {
	Id string `json:"id" db:"id,primary"`
	B  B      `json:"b"`
}

type B struct {
	Id  string `json:"id" db:"id,primary"`
	AId string `json:"a_id" auto:"true"`
}
```