### PR TITLE
:boom: Rename DeleteAll to DeleteAny

### DIFF
--- a/adapter/mysql/mysql_test.go
+++ b/adapter/mysql/mysql_test.go
@@ -87,7 +87,7 @@ func TestAdapter_specs(t *testing.T) {
 	specs.DeleteBelongsTo(t, repo)
 	specs.DeleteHasOne(t, repo)
 	specs.DeleteHasMany(t, repo)
-	specs.DeleteAll(t, repo)
+	specs.DeleteAny(t, repo)
 
 	// Constraint specs
 	// - Check constraint is not supported by mysql

--- a/adapter/postgres/postgres_test.go
+++ b/adapter/postgres/postgres_test.go
@@ -91,7 +91,7 @@ func TestAdapter_specs(t *testing.T) {
 	specs.DeleteBelongsTo(t, repo)
 	specs.DeleteHasOne(t, repo)
 	specs.DeleteHasMany(t, repo)
-	specs.DeleteAll(t, repo)
+	specs.DeleteAny(t, repo)
 
 	// Constraint specs
 	specs.UniqueConstraintOnInsert(t, repo)

--- a/adapter/specs/delete.go
+++ b/adapter/specs/delete.go
@@ -89,8 +89,8 @@ func DeleteHasMany(t *testing.T, repo rel.Repository) {
 	assert.Equal(t, rel.NotFoundError{}, repo.Find(ctx, &Address{}, where.Eq("id", user.Addresses[1].ID)))
 }
 
-// DeleteAll tests delete all specifications.
-func DeleteAll(t *testing.T, repo rel.Repository) {
+// DeleteAny tests delete all specifications.
+func DeleteAny(t *testing.T, repo rel.Repository) {
 	repo.MustInsert(ctx, &User{Name: "delete", Age: 100})
 	repo.MustInsert(ctx, &User{Name: "delete", Age: 100})
 	repo.MustInsert(ctx, &User{Name: "other delete", Age: 110})
@@ -102,11 +102,11 @@ func DeleteAll(t *testing.T, repo rel.Repository) {
 
 	for _, query := range tests {
 		var result []User
-		t.Run("DeleteAll", func(t *testing.T) {
+		t.Run("DeleteAny", func(t *testing.T) {
 			assert.Nil(t, repo.FindAll(ctx, &result, query))
 			assert.NotEqual(t, 0, len(result))
 
-			deletedCount, err := repo.DeleteAll(ctx, query)
+			deletedCount, err := repo.DeleteAny(ctx, query)
 			assert.Nil(t, err)
 			assert.NotZero(t, deletedCount)
 

--- a/adapter/sqlite3/sqlite3_test.go
+++ b/adapter/sqlite3/sqlite3_test.go
@@ -83,7 +83,7 @@ func TestAdapter_specs(t *testing.T) {
 	specs.DeleteBelongsTo(t, repo)
 	specs.DeleteHasOne(t, repo)
 	specs.DeleteHasMany(t, repo)
-	specs.DeleteAll(t, repo)
+	specs.DeleteAny(t, repo)
 
 	// Constraint specs
 	// - foreign key constraint is not supported because of lack of information in the error message.

--- a/reltest/mutate_all.go
+++ b/reltest/mutate_all.go
@@ -59,7 +59,7 @@ func ExpectUpdateAll(r *Repository, query rel.Query, mutates []rel.Mutate) *Muta
 	return expectMutateAll(r, "UpdateAll", r.ctxData, query, mutates)
 }
 
-// ExpectDeleteAll to be called.
-func ExpectDeleteAll(r *Repository, query rel.Query) *MutateAll {
-	return expectMutateAll(r, "DeleteAll", r.ctxData, query)
+// ExpectDeleteAny to be called.
+func ExpectDeleteAny(r *Repository, query rel.Query) *MutateAll {
+	return expectMutateAll(r, "DeleteAny", r.ctxData, query)
 }

--- a/reltest/mutate_all_test.go
+++ b/reltest/mutate_all_test.go
@@ -29,69 +29,69 @@ func TestUpdateAll(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
-func TestDeleteAll(t *testing.T) {
+func TestDeleteAny(t *testing.T) {
 	var (
 		repo = New()
 	)
 
-	repo.ExpectDeleteAll(rel.From("books").Where(where.Eq("id", 1))).Result(1)
-	deletedCount, err := repo.DeleteAll(context.TODO(), rel.From("books").Where(where.Eq("id", 1)))
+	repo.ExpectDeleteAny(rel.From("books").Where(where.Eq("id", 1))).Result(1)
+	deletedCount, err := repo.DeleteAny(context.TODO(), rel.From("books").Where(where.Eq("id", 1)))
 	assert.Nil(t, err)
 	assert.Equal(t, 1, deletedCount)
 	repo.AssertExpectations(t)
 
-	repo.ExpectDeleteAll(rel.From("books").Where(where.Eq("id", 1))).Result(1)
+	repo.ExpectDeleteAny(rel.From("books").Where(where.Eq("id", 1))).Result(1)
 	assert.NotPanics(t, func() {
-		deletedCount = repo.MustDeleteAll(context.TODO(), rel.From("books").Where(where.Eq("id", 1)))
+		deletedCount = repo.MustDeleteAny(context.TODO(), rel.From("books").Where(where.Eq("id", 1)))
 		assert.Equal(t, 1, deletedCount)
 	})
 	repo.AssertExpectations(t)
 }
 
-func TestDeleteAll_error(t *testing.T) {
+func TestDeleteAny_error(t *testing.T) {
 	var (
 		repo = New()
 	)
 
-	repo.ExpectDeleteAll(rel.From("books").Where(where.Eq("id", 1))).ConnectionClosed()
-	_, err := repo.DeleteAll(context.TODO(), rel.From("books").Where(where.Eq("id", 1)))
+	repo.ExpectDeleteAny(rel.From("books").Where(where.Eq("id", 1))).ConnectionClosed()
+	_, err := repo.DeleteAny(context.TODO(), rel.From("books").Where(where.Eq("id", 1)))
 	assert.Equal(t, sql.ErrConnDone, err)
 	repo.AssertExpectations(t)
 
-	repo.ExpectDeleteAll(rel.From("books").Where(where.Eq("id", 1))).ConnectionClosed()
+	repo.ExpectDeleteAny(rel.From("books").Where(where.Eq("id", 1))).ConnectionClosed()
 	assert.Panics(t, func() {
-		repo.MustDeleteAll(context.TODO(), rel.From("books").Where(where.Eq("id", 1)))
+		repo.MustDeleteAny(context.TODO(), rel.From("books").Where(where.Eq("id", 1)))
 	})
 	repo.AssertExpectations(t)
 }
 
-func TestDeleteAll_noTable(t *testing.T) {
+func TestDeleteAny_noTable(t *testing.T) {
 	var (
 		repo  = New()
 		query = rel.Where(where.Eq("id", 1))
 	)
 
-	repo.ExpectDeleteAll(query)
+	repo.ExpectDeleteAny(query)
 	assert.Panics(t, func() {
-		repo.MustDeleteAll(context.TODO(), query)
+		repo.MustDeleteAny(context.TODO(), query)
 	})
 	repo.AssertExpectations(t)
 }
 
-func TestDeleteAll_unsafe(t *testing.T) {
+func TestDeleteAny_unsafe(t *testing.T) {
 	var (
 		repo = New()
 	)
 
-	repo.ExpectDeleteAll(rel.From("books"))
+	repo.ExpectDeleteAny(rel.From("books"))
 	assert.Panics(t, func() {
-		repo.MustDeleteAll(context.TODO(), rel.From("books"))
+		repo.MustDeleteAny(context.TODO(), rel.From("books"))
 	})
 	repo.AssertExpectations(t)
 
-	repo.ExpectDeleteAll(rel.From("books")).Unsafe()
+	repo.ExpectDeleteAny(rel.From("books")).Unsafe()
 	assert.NotPanics(t, func() {
-		repo.MustDeleteAll(context.TODO(), rel.From("books"))
+		repo.MustDeleteAny(context.TODO(), rel.From("books"))
 	})
 	repo.AssertExpectations(t)
 }

--- a/reltest/repository.go
+++ b/reltest/repository.go
@@ -225,22 +225,22 @@ func (r *Repository) ExpectDelete(options ...rel.Cascade) *Delete {
 	return ExpectDelete(r, options)
 }
 
-// DeleteAll provides a mock function with given fields: query
-func (r *Repository) DeleteAll(ctx context.Context, query rel.Query) (int, error) {
+// DeleteAny provides a mock function with given fields: query
+func (r *Repository) DeleteAny(ctx context.Context, query rel.Query) (int, error) {
 	ret := r.mock.Called(fetchContext(ctx), query)
 	return ret.Int(0), ret.Error(1)
 }
 
-// MustDeleteAll provides a mock function with given fields: query
-func (r *Repository) MustDeleteAll(ctx context.Context, query rel.Query) int {
-	deletedCount, err := r.DeleteAll(ctx, query)
+// MustDeleteAny provides a mock function with given fields: query
+func (r *Repository) MustDeleteAny(ctx context.Context, query rel.Query) int {
+	deletedCount, err := r.DeleteAny(ctx, query)
 	must(err)
 	return deletedCount
 }
 
-// ExpectDeleteAll apply mocks and expectations for DeleteAll
-func (r *Repository) ExpectDeleteAll(query rel.Query) *MutateAll {
-	return ExpectDeleteAll(r, query)
+// ExpectDeleteAny apply mocks and expectations for DeleteAny
+func (r *Repository) ExpectDeleteAny(query rel.Query) *MutateAll {
+	return ExpectDeleteAny(r, query)
 }
 
 // Preload provides a mock function with given fields: records, field, queriers

--- a/repository_test.go
+++ b/repository_test.go
@@ -2387,7 +2387,7 @@ func TestRepository_saveHasMany_replace(t *testing.T) {
 	adapter.AssertExpectations(t)
 }
 
-func TestRepository_saveHasMany_replaceDeleteAllError(t *testing.T) {
+func TestRepository_saveHasMany_replaceDeleteAnyError(t *testing.T) {
 	var (
 		adapter = &testAdapter{}
 		cw      = fetchContext(context.TODO(), adapter)
@@ -2755,7 +2755,7 @@ func TestRepository_MustDelete(t *testing.T) {
 	adapter.AssertExpectations(t)
 }
 
-func TestRepository_DeleteAll(t *testing.T) {
+func TestRepository_DeleteAny(t *testing.T) {
 	var (
 		adapter = &testAdapter{}
 		repo    = New(adapter)
@@ -2764,14 +2764,14 @@ func TestRepository_DeleteAll(t *testing.T) {
 
 	adapter.On("Delete", From("logs").Where(Eq("user_id", 1))).Return(1, nil).Once()
 
-	deletedCount, err := repo.DeleteAll(context.TODO(), queries)
+	deletedCount, err := repo.DeleteAny(context.TODO(), queries)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, deletedCount)
 
 	adapter.AssertExpectations(t)
 }
 
-func TestRepository_MustDeleteAll(t *testing.T) {
+func TestRepository_MustDeleteAny(t *testing.T) {
 	var (
 		adapter = &testAdapter{}
 		repo    = New(adapter)
@@ -2781,7 +2781,7 @@ func TestRepository_MustDeleteAll(t *testing.T) {
 	adapter.On("Delete", From("logs").Where(Eq("user_id", 1))).Return(1, nil).Once()
 
 	assert.NotPanics(t, func() {
-		deletedCount := repo.MustDeleteAll(context.TODO(), queries)
+		deletedCount := repo.MustDeleteAny(context.TODO(), queries)
 		assert.Equal(t, 1, deletedCount)
 	})
 


### PR DESCRIPTION
- DeleteAll will be reserved for operation that accepts structs like FindAll or InsertAll (and soon added DeleteAll that accepts structs)