### PR TITLE
Support NotFoundError is sql.ErrNoRows

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,5 +1,10 @@
 package rel
 
+import (
+	"database/sql"
+	"errors"
+)
+
 var (
 	// ErrNotFound returned when records not found.
 	ErrNotFound = NotFoundError{}
@@ -31,6 +36,11 @@ type NotFoundError struct{}
 // Error message.
 func (nfe NotFoundError) Error() string {
 	return "Record not found"
+}
+
+// Is returns true when target error is sql.ErrNoRows.
+func (nfe NotFoundError) Is(target error) bool {
+	return errors.Is(target, sql.ErrNoRows)
 }
 
 // ConstraintType defines the type of constraint error.

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,6 +1,7 @@
 package rel
 
 import (
+	"database/sql"
 	"errors"
 	"testing"
 
@@ -9,6 +10,31 @@ import (
 
 func TestNoResultError(t *testing.T) {
 	assert.Equal(t, "Record not found", NotFoundError{}.Error())
+}
+
+func TestNotFoundError_Is(t *testing.T) {
+	tests := []struct {
+		err    NotFoundError
+		target error
+		equal  bool
+	}{
+		{
+			err:    NotFoundError{},
+			target: NotFoundError{},
+			equal:  true,
+		},
+		{
+			err:    NotFoundError{},
+			target: sql.ErrNoRows,
+			equal:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.err.Error(), func(t *testing.T) {
+			assert.Equal(t, test.equal, test.err.Is(test.target))
+		})
+	}
 }
 
 func TestConstraintType(t *testing.T) {


### PR DESCRIPTION
Sometimes we're more used to it:
  
```
err := rel.Find(ctx,&user{},query)
if errors.Is(err, sql.ErrNoRows) {
...
}
```

