### PR TITLE
 Set pointer association fields to nil if preload fails

### DIFF
--- a/association.go
+++ b/association.go
@@ -52,6 +52,17 @@ func (a Association) Type() AssociationType {
 // Document returns association target as document.
 // If association is zero, second return value will be false.
 func (a Association) Document() (*Document, bool) {
+	return a.document(false)
+}
+
+// LazyDocument is a lazy version of Document.
+// If rv is a null pointer, it returns a document that delays setting the value of rv
+// until Document#Add() is called.
+func (a Association) LazyDocument() (*Document, bool) {
+	return a.document(true)
+}
+
+func (a Association) document(lazy bool) (*Document, bool) {
 	var (
 		rv = a.rv.FieldByIndex(a.data.targetIndex)
 	)
@@ -59,7 +70,10 @@ func (a Association) Document() (*Document, bool) {
 	switch rv.Kind() {
 	case reflect.Ptr:
 		if rv.IsNil() {
-			rv.Set(reflect.New(rv.Type().Elem()))
+			if !lazy {
+				rv.Set(reflect.New(rv.Type().Elem()))
+			}
+
 			return NewDocument(rv), false
 		}
 

--- a/document.go
+++ b/document.go
@@ -335,8 +335,14 @@ func (d Document) Association(name string) Association {
 func (d Document) Reset() {
 }
 
-// Add returns this document, this is a noop for compatibility with collection.
+// Add returns this document.
 func (d *Document) Add() *Document {
+	// if d.rv is a null pointer, set it to a new struct.
+	if d.rv.Kind() == reflect.Ptr && d.rv.IsNil() {
+		d.rv.Set(reflect.New(d.rv.Type().Elem()))
+		d.rv = d.rv.Elem()
+	}
+
 	return d
 }
 
@@ -382,7 +388,9 @@ func newDocument(v interface{}, rv reflect.Value, readonly bool) *Document {
 			panic("rel: must be a pointer to struct")
 		}
 	} else {
-		rv = rv.Elem()
+		if !rv.IsNil() {
+			rv = rv.Elem()
+		}
 		rt = rt.Elem()
 	}
 

--- a/rel_test.go
+++ b/rel_test.go
@@ -21,7 +21,7 @@ type User struct {
 	Age          int
 	Transactions []Transaction `ref:"id" fk:"user_id"`
 	Address      Address       `autosave:"true"`
-	WorkAddress  Address
+	WorkAddress  *Address
 	UserRoles    []UserRole `autosave:"true"`
 	Emails       []Email    `autosave:"true"`
 

--- a/repository.go
+++ b/repository.go
@@ -990,75 +990,7 @@ func (r repository) preload(cw contextWrapper, records slice, field string, quer
 	scanFinish := r.instrumenter.Observe(cw.ctx, "rel-scan-multi", "scanning all records to multiple targets")
 	defer scanFinish(nil)
 
-	err = scanMulti(cur, keyField, keyType, targets)
-	if err != nil {
-		return err
-	}
-
-	return cleanUpAssociationFields(records, field, path)
-}
-
-// cleanUpAssociationFields sets the value of the corresponding "has one" or "belongs to" association field
-// to a zero value if the preload fails (not found).
-func cleanUpAssociationFields(sl slice, field string, path []string) error {
-	type frame struct {
-		index int
-		doc   *Document
-	}
-
-	var (
-		stack = make([]frame, sl.Len())
-	)
-
-	// init stack
-	for i := 0; i < len(stack); i++ {
-		stack[i] = frame{index: 0, doc: sl.Get(i)}
-	}
-
-	for len(stack) > 0 {
-		var (
-			n      = len(stack) - 1
-			top    = stack[n]
-			assocs = top.doc.Association(path[top.index])
-		)
-
-		stack = stack[:n]
-
-		if top.index == len(path)-1 {
-			if assocs.Type() != HasMany {
-				if assocs.IsZero() {
-					top.doc.SetValue(path[len(path)-1], nil)
-				}
-			}
-		} else {
-			if assocs.Type() == HasMany {
-				var (
-					col, loaded = assocs.Collection()
-				)
-
-				if !loaded {
-					continue
-				}
-
-				stack = append(stack, make([]frame, col.Len())...)
-				for i := 0; i < col.Len(); i++ {
-					stack[n+i] = frame{
-						index: top.index + 1,
-						doc:   col.Get(i),
-					}
-				}
-			} else {
-				if doc, loaded := assocs.Document(); loaded {
-					stack = append(stack, frame{
-						index: top.index + 1,
-						doc:   doc,
-					})
-				}
-			}
-		}
-	}
-
-	return nil
+	return scanMulti(cur, keyField, keyType, targets)
 }
 
 func (r repository) MustPreload(ctx context.Context, records interface{}, field string, queriers ...Querier) {
@@ -1109,7 +1041,7 @@ func (r repository) mapPreloadTargets(sl slice, path []string) (map[interface{}]
 			if assocs.Type() == HasMany {
 				target, targetLoaded = assocs.Collection()
 			} else {
-				target, targetLoaded = assocs.Document()
+				target, targetLoaded = assocs.LazyDocument()
 			}
 
 			target.Reset()

--- a/repository_test.go
+++ b/repository_test.go
@@ -2854,6 +2854,30 @@ func TestRepository_Preload_hasOne(t *testing.T) {
 	cur.AssertExpectations(t)
 }
 
+func TestRepository_Preload_ptrHasOne(t *testing.T) {
+	var (
+		adapter = &testAdapter{}
+		repo    = New(adapter)
+		user    = User{ID: 10}
+		address = Address{ID: 100, UserID: &user.ID}
+		cur     = &testCursor{}
+	)
+
+	adapter.On("Query", From("addresses").Where(In("user_id", 10).AndNil("deleted_at"))).Return(cur, nil).Once()
+
+	cur.On("Close").Return(nil).Once()
+	cur.On("Fields").Return([]string{"id", "user_id"}, nil).Once()
+	cur.On("Next").Return(true).Once()
+	cur.MockScan(address.ID, *address.UserID).Times(2)
+	cur.On("Next").Return(false).Once()
+
+	assert.Nil(t, repo.Preload(context.TODO(), &user, "work_address"))
+	assert.Equal(t, &address, user.WorkAddress)
+
+	adapter.AssertExpectations(t)
+	cur.AssertExpectations(t)
+}
+
 func TestRepository_Preload_ptrHasOne_notFound_null(t *testing.T) {
 	var (
 		adapter = &testAdapter{}
@@ -2874,6 +2898,7 @@ func TestRepository_Preload_ptrHasOne_notFound_null(t *testing.T) {
 	adapter.AssertExpectations(t)
 	cur.AssertExpectations(t)
 }
+
 func TestRepository_Preload_sliceHasOne(t *testing.T) {
 	var (
 		adapter   = &testAdapter{}
@@ -2900,6 +2925,37 @@ func TestRepository_Preload_sliceHasOne(t *testing.T) {
 	assert.Nil(t, repo.Preload(context.TODO(), &users, "address"))
 	assert.Equal(t, addresses[0], users[0].Address)
 	assert.Equal(t, addresses[1], users[1].Address)
+
+	adapter.AssertExpectations(t)
+	cur.AssertExpectations(t)
+}
+
+func TestRepository_Preload_ptrSliceHasOne(t *testing.T) {
+	var (
+		adapter   = &testAdapter{}
+		repo      = New(adapter)
+		users     = []User{{ID: 10}, {ID: 20}}
+		addresses = []Address{
+			{ID: 100, UserID: &users[0].ID},
+			{ID: 200, UserID: &users[1].ID},
+		}
+		cur = &testCursor{}
+	)
+
+	// one of these, because of map ordering
+	adapter.On("Query", From("addresses").Where(In("user_id", 10, 20).AndNil("deleted_at"))).Return(cur, nil).Maybe()
+	adapter.On("Query", From("addresses").Where(In("user_id", 20, 10).AndNil("deleted_at"))).Return(cur, nil).Maybe()
+
+	cur.On("Close").Return(nil).Once()
+	cur.On("Fields").Return([]string{"id", "user_id"}, nil).Once()
+	cur.On("Next").Return(true).Twice()
+	cur.MockScan(addresses[0].ID, *addresses[0].UserID).Twice()
+	cur.MockScan(addresses[1].ID, *addresses[1].UserID).Twice()
+	cur.On("Next").Return(false).Once()
+
+	assert.Nil(t, repo.Preload(context.TODO(), &users, "work_address"))
+	assert.Equal(t, &addresses[0], users[0].WorkAddress)
+	assert.Equal(t, &addresses[1], users[1].WorkAddress)
 
 	adapter.AssertExpectations(t)
 	cur.AssertExpectations(t)
@@ -2949,6 +3005,32 @@ func TestRepository_Preload_nestedHasOne(t *testing.T) {
 
 	assert.Nil(t, repo.Preload(context.TODO(), &transaction, "buyer.address"))
 	assert.Equal(t, address, transaction.Buyer.Address)
+
+	adapter.AssertExpectations(t)
+	cur.AssertExpectations(t)
+}
+
+func TestRepository_Preload_ptrNestedHasOne(t *testing.T) {
+	var (
+		adapter     = &testAdapter{}
+		repo        = New(adapter)
+		transaction = Transaction{
+			Buyer: User{ID: 10},
+		}
+		address = Address{ID: 100, UserID: &transaction.Buyer.ID}
+		cur     = &testCursor{}
+	)
+
+	adapter.On("Query", From("addresses").Where(In("user_id", 10).AndNil("deleted_at"))).Return(cur, nil).Once()
+
+	cur.On("Close").Return(nil).Once()
+	cur.On("Fields").Return([]string{"id", "user_id"}, nil).Once()
+	cur.On("Next").Return(true).Once()
+	cur.MockScan(address.ID, *address.UserID).Twice()
+	cur.On("Next").Return(false).Once()
+
+	assert.Nil(t, repo.Preload(context.TODO(), &transaction, "buyer.work_address"))
+	assert.Equal(t, &address, transaction.Buyer.WorkAddress)
 
 	adapter.AssertExpectations(t)
 	cur.AssertExpectations(t)
@@ -3006,6 +3088,40 @@ func TestRepository_Preload_sliceNestedHasOne(t *testing.T) {
 	assert.Nil(t, repo.Preload(context.TODO(), &transactions, "buyer.address"))
 	assert.Equal(t, addresses[0], transactions[0].Buyer.Address)
 	assert.Equal(t, addresses[1], transactions[1].Buyer.Address)
+
+	adapter.AssertExpectations(t)
+	cur.AssertExpectations(t)
+}
+
+func TestRepository_Preload_ptrSliceNestedHasOne(t *testing.T) {
+	var (
+		adapter      = &testAdapter{}
+		repo         = New(adapter)
+		transactions = []Transaction{
+			{Buyer: User{ID: 10}},
+			{Buyer: User{ID: 20}},
+		}
+		addresses = []Address{
+			{ID: 100, UserID: &transactions[0].Buyer.ID},
+			{ID: 200, UserID: &transactions[1].Buyer.ID},
+		}
+		cur = &testCursor{}
+	)
+
+	// one of these, because of map ordering
+	adapter.On("Query", From("addresses").Where(In("user_id", 10, 20).AndNil("deleted_at"))).Return(cur, nil).Maybe()
+	adapter.On("Query", From("addresses").Where(In("user_id", 20, 10).AndNil("deleted_at"))).Return(cur, nil).Maybe()
+
+	cur.On("Close").Return(nil).Once()
+	cur.On("Fields").Return([]string{"id", "user_id"}, nil).Once()
+	cur.On("Next").Return(true).Twice()
+	cur.MockScan(addresses[0].ID, *addresses[0].UserID).Twice()
+	cur.MockScan(addresses[1].ID, *addresses[1].UserID).Twice()
+	cur.On("Next").Return(false).Once()
+
+	assert.Nil(t, repo.Preload(context.TODO(), &transactions, "buyer.work_address"))
+	assert.Equal(t, &addresses[0], transactions[0].Buyer.WorkAddress)
+	assert.Equal(t, &addresses[1], transactions[1].Buyer.WorkAddress)
 
 	adapter.AssertExpectations(t)
 	cur.AssertExpectations(t)

--- a/repository_test.go
+++ b/repository_test.go
@@ -2854,6 +2854,26 @@ func TestRepository_Preload_hasOne(t *testing.T) {
 	cur.AssertExpectations(t)
 }
 
+func TestRepository_Preload_ptrHasOne_notFound_null(t *testing.T) {
+	var (
+		adapter = &testAdapter{}
+		repo    = New(adapter)
+		user    = User{ID: 10}
+		cur     = &testCursor{}
+	)
+
+	adapter.On("Query", From("addresses").Where(In("user_id", 10).AndNil("deleted_at"))).Return(cur, nil).Once()
+
+	cur.On("Close").Return(nil).Once()
+	cur.On("Fields").Return([]string{"id", "user_id"}, nil).Once()
+	cur.On("Next").Return(false).Once()
+
+	assert.Nil(t, repo.Preload(context.TODO(), &user, "work_address"))
+	assert.Nil(t, user.WorkAddress)
+
+	adapter.AssertExpectations(t)
+	cur.AssertExpectations(t)
+}
 func TestRepository_Preload_sliceHasOne(t *testing.T) {
 	var (
 		adapter   = &testAdapter{}
@@ -2885,6 +2905,29 @@ func TestRepository_Preload_sliceHasOne(t *testing.T) {
 	cur.AssertExpectations(t)
 }
 
+func TestRepository_Preload_ptrSliceHasOne_notFound_null(t *testing.T) {
+	var (
+		adapter = &testAdapter{}
+		repo    = New(adapter)
+		users   = []User{{ID: 10}, {ID: 20}}
+		cur     = &testCursor{}
+	)
+
+	adapter.On("Query", From("addresses").Where(In("user_id", 10, 20).AndNil("deleted_at"))).Return(cur, nil).Maybe()
+	adapter.On("Query", From("addresses").Where(In("user_id", 20, 10).AndNil("deleted_at"))).Return(cur, nil).Maybe()
+
+	cur.On("Close").Return(nil).Once()
+	cur.On("Fields").Return([]string{"id", "user_id"}, nil).Once()
+	cur.On("Next").Return(false).Once()
+
+	assert.Nil(t, repo.Preload(context.TODO(), &users, "work_address"))
+	assert.Nil(t, users[0].WorkAddress)
+	assert.Nil(t, users[1].WorkAddress)
+
+	adapter.AssertExpectations(t)
+	cur.AssertExpectations(t)
+}
+
 func TestRepository_Preload_nestedHasOne(t *testing.T) {
 	var (
 		adapter     = &testAdapter{}
@@ -2906,6 +2949,29 @@ func TestRepository_Preload_nestedHasOne(t *testing.T) {
 
 	assert.Nil(t, repo.Preload(context.TODO(), &transaction, "buyer.address"))
 	assert.Equal(t, address, transaction.Buyer.Address)
+
+	adapter.AssertExpectations(t)
+	cur.AssertExpectations(t)
+}
+
+func TestRepository_Preload_ptrNestedHasOne_notFound_null(t *testing.T) {
+	var (
+		adapter     = &testAdapter{}
+		repo        = New(adapter)
+		transaction = Transaction{
+			Buyer: User{ID: 10},
+		}
+		cur = &testCursor{}
+	)
+
+	adapter.On("Query", From("addresses").Where(In("user_id", 10).AndNil("deleted_at"))).Return(cur, nil).Once()
+
+	cur.On("Close").Return(nil).Once()
+	cur.On("Fields").Return([]string{"id", "user_id"}, nil).Once()
+	cur.On("Next").Return(false).Once()
+
+	assert.Nil(t, repo.Preload(context.TODO(), &transaction, "buyer.work_address"))
+	assert.Nil(t, transaction.Buyer.WorkAddress)
 
 	adapter.AssertExpectations(t)
 	cur.AssertExpectations(t)
@@ -2940,6 +3006,32 @@ func TestRepository_Preload_sliceNestedHasOne(t *testing.T) {
 	assert.Nil(t, repo.Preload(context.TODO(), &transactions, "buyer.address"))
 	assert.Equal(t, addresses[0], transactions[0].Buyer.Address)
 	assert.Equal(t, addresses[1], transactions[1].Buyer.Address)
+
+	adapter.AssertExpectations(t)
+	cur.AssertExpectations(t)
+}
+
+func TestRepository_Preload_ptrSliceNestedHasOne_notFound_null(t *testing.T) {
+	var (
+		adapter      = &testAdapter{}
+		repo         = New(adapter)
+		transactions = []Transaction{
+			{Buyer: User{ID: 10}},
+			{Buyer: User{ID: 20}},
+		}
+		cur = &testCursor{}
+	)
+
+	adapter.On("Query", From("addresses").Where(In("user_id", 10, 20).AndNil("deleted_at"))).Return(cur, nil).Maybe()
+	adapter.On("Query", From("addresses").Where(In("user_id", 20, 10).AndNil("deleted_at"))).Return(cur, nil).Maybe()
+
+	cur.On("Close").Return(nil).Once()
+	cur.On("Fields").Return([]string{"id", "user_id"}, nil).Once()
+	cur.On("Next").Return(false).Once()
+
+	assert.Nil(t, repo.Preload(context.TODO(), &transactions, "buyer.work_address"))
+	assert.Nil(t, transactions[0].Buyer.WorkAddress)
+	assert.Nil(t, transactions[1].Buyer.WorkAddress)
 
 	adapter.AssertExpectations(t)
 	cur.AssertExpectations(t)
@@ -3183,6 +3275,28 @@ func TestRepository_Preload_nullBelongsTo(t *testing.T) {
 	adapter.AssertExpectations(t)
 }
 
+func TestRepository_Preload_ptrBelongsTo_notFound_null(t *testing.T) {
+	var (
+		adapter = &testAdapter{}
+		repo    = New(adapter)
+		userID  = 10
+		address = Address{UserID: &userID}
+		cur     = &testCursor{}
+	)
+
+	adapter.On("Query", From("users").Where(In("id", 10))).Return(cur, nil).Once()
+
+	cur.On("Close").Return(nil).Once()
+	cur.On("Fields").Return([]string{"id", "name"}, nil).Once()
+	cur.On("Next").Return(false).Once()
+
+	assert.Nil(t, repo.Preload(context.TODO(), &address, "user"))
+	assert.Nil(t, address.User)
+
+	adapter.AssertExpectations(t)
+	cur.AssertExpectations(t)
+}
+
 func TestRepository_Preload_sliceBelongsTo(t *testing.T) {
 	var (
 		adapter      = &testAdapter{}
@@ -3244,6 +3358,36 @@ func TestRepository_Preload_ptrSliceBelongsTo(t *testing.T) {
 	assert.Nil(t, repo.Preload(context.TODO(), &addresses, "user"))
 	assert.Equal(t, users[0], *addresses[0].User)
 	assert.Equal(t, users[1], *addresses[1].User)
+
+	adapter.AssertExpectations(t)
+	cur.AssertExpectations(t)
+}
+
+func TestRepository_Preload_ptrSliceBelongsTo_notFound_null(t *testing.T) {
+	var (
+		adapter = &testAdapter{}
+		repo    = New(adapter)
+		users   = []User{
+			{ID: 10, Name: "Del Piero"},
+			{ID: 20, Name: "Nedved"},
+		}
+		addresses = []Address{
+			{UserID: &users[0].ID},
+			{UserID: &users[1].ID},
+		}
+		cur = &testCursor{}
+	)
+
+	adapter.On("Query", From("users").Where(In("id", 10, 20))).Return(cur, nil).Maybe()
+	adapter.On("Query", From("users").Where(In("id", 20, 10))).Return(cur, nil).Maybe()
+
+	cur.On("Close").Return(nil).Once()
+	cur.On("Fields").Return([]string{"id", "name"}, nil).Once()
+	cur.On("Next").Return(false).Once()
+
+	assert.Nil(t, repo.Preload(context.TODO(), &addresses, "user"))
+	assert.Nil(t, addresses[0].User)
+	assert.Nil(t, addresses[1].User)
 
 	adapter.AssertExpectations(t)
 	cur.AssertExpectations(t)


### PR DESCRIPTION
If the "has one" or "belongs to" association field is a pointer and the preload fails (not found), the value of the field will be nil instead of a zero-valued pointer.

This allows you to check if an association exists by simply looking at whether the field is nil or not.