### PR TITLE
If the preload fails, the intermediate association fields will also remain nil

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -1079,7 +1079,7 @@ func (r repository) mapPreloadTargets(sl slice, path []string) (map[interface{}]
 					}
 				}
 			} else {
-				if doc, loaded := assocs.Document(); loaded {
+				if doc, loaded := assocs.LazyDocument(); loaded {
 					stack = append(stack, frame{
 						index: top.index + 1,
 						doc:   doc,

--- a/repository_test.go
+++ b/repository_test.go
@@ -3252,6 +3252,7 @@ func TestRepository_Preload_nestedNullHasMany(t *testing.T) {
 	)
 
 	assert.Nil(t, repo.Preload(context.TODO(), &address, "user.transactions"))
+	assert.Nil(t, address.User)
 
 	adapter.AssertExpectations(t)
 }
@@ -3323,7 +3324,7 @@ func TestRepository_Preload_nestedNullSliceHasMany(t *testing.T) {
 
 	assert.Nil(t, repo.Preload(context.TODO(), &addresses, "user.transactions"))
 	assert.Equal(t, transactions[:2], addresses[0].User.Transactions)
-	assert.Equal(t, []Transaction(nil), addresses[1].User.Transactions)
+	assert.Nil(t, addresses[1].User)
 	assert.Equal(t, transactions[2:], addresses[2].User.Transactions)
 
 	adapter.AssertExpectations(t)


### PR DESCRIPTION
Related to #197 