### PR TITLE
Suppressing unexpected not found error

### DIFF
--- a/adapter/specs/update.go
+++ b/adapter/specs/update.go
@@ -55,7 +55,7 @@ func UpdateNotFound(t *testing.T, repo rel.Repository) {
 	)
 
 	// update unchanged
-	assert.Equal(t, rel.NotFoundError{}, repo.Update(ctx, &user))
+	assert.Equal(t, nil, repo.Update(ctx, &user))
 }
 
 // UpdateHasManyInsert tests specification for updating a record and inserting has many association.

--- a/repository.go
+++ b/repository.go
@@ -508,10 +508,8 @@ func (r repository) update(cw contextWrapper, doc *Document, mutation Mutation, 
 			pField = doc.PrimaryField()
 		}
 
-		if updatedCount, err := cw.adapter.Update(cw.ctx, query, pField, mutation.Mutates); err != nil {
+		if _, err := cw.adapter.Update(cw.ctx, query, pField, mutation.Mutates); err != nil {
 			return mutation.ErrorFunc.transform(err)
-		} else if updatedCount == 0 {
-			return NotFoundError{}
 		}
 
 		if mutation.Reload {
@@ -797,11 +795,7 @@ func (r repository) delete(cw contextWrapper, doc *Document, filter FilterQuery,
 		}
 	}
 
-	deletedCount, err := r.deleteAny(cw, doc.data.flag, query)
-	if err == nil && deletedCount == 0 {
-		err = NotFoundError{}
-	}
-
+	_, err := r.deleteAny(cw, doc.data.flag, query)
 	if err == nil && cascade {
 		if err := r.deleteBelongsTo(cw, doc, cascade); err != nil {
 			return err

--- a/repository_test.go
+++ b/repository_test.go
@@ -1285,29 +1285,6 @@ func TestRepository_Update_softDeleteUnscoped(t *testing.T) {
 	adapter.AssertExpectations(t)
 }
 
-func TestRepository_Update_notFound(t *testing.T) {
-	var (
-		user     = User{ID: 1}
-		adapter  = &testAdapter{}
-		repo     = New(adapter)
-		mutators = []Mutator{
-			Set("name", "name"),
-			Set("updated_at", now()),
-		}
-		mutates = map[string]Mutate{
-			"name":       Set("name", "name"),
-			"updated_at": Set("updated_at", now()),
-		}
-		queries = From("users").Where(Eq("id", user.ID))
-	)
-
-	adapter.On("Update", queries, "id", mutates).Return(0, nil).Once()
-
-	assert.Equal(t, NotFoundError{}, repo.Update(context.TODO(), &user, mutators...))
-
-	adapter.AssertExpectations(t)
-}
-
 func TestRepository_Update_reload(t *testing.T) {
 	var (
 		user     = User{ID: 1}
@@ -2497,20 +2474,6 @@ func TestRepository_Delete_compositePrimaryKey(t *testing.T) {
 	adapter.On("Delete", From("user_roles").Where(Eq("user_id", userRole.UserID).AndEq("role_id", userRole.RoleID))).Return(1, nil).Once()
 
 	assert.Nil(t, repo.Delete(context.TODO(), &userRole))
-
-	adapter.AssertExpectations(t)
-}
-
-func TestRepository_Delete_notFound(t *testing.T) {
-	var (
-		adapter = &testAdapter{}
-		repo    = New(adapter)
-		user    = User{ID: 1}
-	)
-
-	adapter.On("Delete", From("users").Where(Eq("id", user.ID))).Return(0, nil).Once()
-
-	assert.Equal(t, NotFoundError{}, repo.Delete(context.TODO(), &user))
 
 	adapter.AssertExpectations(t)
 }


### PR DESCRIPTION
In some databases, affected row count can be zero if the data is exactly the same, even if the update row exists.
This will result in an unexpected error.
It is better to leave it to the user to decide whether to make an error on the value of affected row count or not.