### PR TITLE
Deprecate builtin sqlite3 package

### DIFF
--- a/adapter/sqlite3/sqlite3.go
+++ b/adapter/sqlite3/sqlite3.go
@@ -1,5 +1,7 @@
 // Package sqlite3 wraps go-sqlite3 driver as an adapter for rel.
 //
+// Deprecated: Please use github.com/go-rel/sqlite3 instead.
+//
 // Usage:
 //	// open sqlite3 connection.
 //	adapter, err := sqlite3.Open("dev.db")


### PR DESCRIPTION
-  Latest version available at: `github.com/go-rel/sqlite3`