### PR TITLE
Allow FilterQuery to be specified for partial indexes and unique key constraints

### DIFF
--- a/filter_query.go
+++ b/filter_query.go
@@ -187,6 +187,14 @@ func (fq FilterQuery) or(other FilterQuery) FilterQuery {
 	return Or(fq, other)
 }
 
+func (fq FilterQuery) applyKey(key *Key) {
+	key.Filter = fq
+}
+
+func (fq FilterQuery) applyIndex(index *Index) {
+	index.Filter = fq
+}
+
 // AndEq append equal expression using and.
 func (fq FilterQuery) AndEq(field string, value interface{}) FilterQuery {
 	return fq.and(Eq(field, value))

--- a/index.go
+++ b/index.go
@@ -8,6 +8,7 @@ type Index struct {
 	Unique   bool
 	Columns  []string
 	Optional bool
+	Filter   FilterQuery
 	Options  string
 }
 

--- a/index_test.go
+++ b/index_test.go
@@ -41,6 +41,29 @@ func TestCreateUniqueIndex(t *testing.T) {
 	}, index)
 }
 
+func TestCreateFilteredUniqueIndex(t *testing.T) {
+	var (
+		options = []IndexOption{
+			Options("options"),
+			Eq("deleted", false),
+		}
+		index = createUniqueIndex("table", "add_idx", []string{"add"}, options)
+	)
+
+	assert.Equal(t, Index{
+		Table:   "table",
+		Name:    "add_idx",
+		Unique:  true,
+		Columns: []string{"add"},
+		Filter: FilterQuery{
+			Type:  FilterEqOp,
+			Field: "deleted",
+			Value: false,
+		},
+		Options: "options",
+	}, index)
+}
+
 func TestDropIndex(t *testing.T) {
 	var (
 		options = []IndexOption{

--- a/key.go
+++ b/key.go
@@ -28,6 +28,7 @@ type Key struct {
 	Columns   []string
 	Rename    string
 	Reference ForeignKeyReference
+	Filter    FilterQuery
 	Options   string
 }
 

--- a/key_test.go
+++ b/key_test.go
@@ -31,6 +31,29 @@ func TestCreateForeignKey(t *testing.T) {
 	}, index)
 }
 
+func TestCreateFilteredUniqueKey(t *testing.T) {
+	var (
+		options = []KeyOption{
+			Name("uq"),
+			Eq("deleted", false),
+			Options("options"),
+		}
+		index = createKeys([]string{"code"}, UniqueKey, options)
+	)
+
+	assert.Equal(t, Key{
+		Type:    UniqueKey,
+		Name:    "uq",
+		Columns: []string{"code"},
+		Filter: FilterQuery{
+			Type:  FilterEqOp,
+			Field: "deleted",
+			Value: false,
+		},
+		Options: "options",
+	}, index)
+}
+
 func TestKey_InternalTableDefinition(t *testing.T) {
 	assert.NotPanics(t, func() { Key{}.internalTableDefinition() })
 }


### PR DESCRIPTION
Related to #218 and needed to further implement this in adapters