### PR TITLE
Remove Filter for key as it is not directly supported by SQL

### DIFF
--- a/filter_query.go
+++ b/filter_query.go
@@ -187,10 +187,6 @@ func (fq FilterQuery) or(other FilterQuery) FilterQuery {
 	return Or(fq, other)
 }
 
-func (fq FilterQuery) applyKey(key *Key) {
-	key.Filter = fq
-}
-
 func (fq FilterQuery) applyIndex(index *Index) {
 	index.Filter = fq
 }

--- a/key.go
+++ b/key.go
@@ -28,7 +28,6 @@ type Key struct {
 	Columns   []string
 	Rename    string
 	Reference ForeignKeyReference
-	Filter    FilterQuery
 	Options   string
 }
 

--- a/key_test.go
+++ b/key_test.go
@@ -31,11 +31,10 @@ func TestCreateForeignKey(t *testing.T) {
 	}, index)
 }
 
-func TestCreateFilteredUniqueKey(t *testing.T) {
+func TestCreateUniqueKey(t *testing.T) {
 	var (
 		options = []KeyOption{
 			Name("uq"),
-			Eq("deleted", false),
 			Options("options"),
 		}
 		index = createKeys([]string{"code"}, UniqueKey, options)
@@ -45,11 +44,6 @@ func TestCreateFilteredUniqueKey(t *testing.T) {
 		Type:    UniqueKey,
 		Name:    "uq",
 		Columns: []string{"code"},
-		Filter: FilterQuery{
-			Type:  FilterEqOp,
-			Field: "deleted",
-			Value: false,
-		},
 		Options: "options",
 	}, index)
 }


### PR DESCRIPTION
Partially revert #219

This would complicate implementation as it's only supported for indexes (including unique indexes) and would require to create index separately anyway in such case.

Sorry for rushed previous PR.