### PR TITLE
support `IN` clause with empty values in MySQL

### DIFF
--- a/adapter/sql/builder.go
+++ b/adapter/sql/builder.go
@@ -787,15 +787,23 @@ func (b *Builder) buildInclusion(buffer *Buffer, filter rel.FilterQuery) {
 		values = filter.Value.([]interface{})
 	)
 
-	buffer.WriteString(Escape(b.config, filter.Field))
-
-	if filter.Type == rel.FilterInOp {
-		buffer.WriteString(" IN ")
+	if len(values) == 0 {
+		if filter.Type == rel.FilterInOp {
+			buffer.WriteString("1=0")
+		} else {
+			buffer.WriteString("1=1")
+		}
 	} else {
-		buffer.WriteString(" NOT IN ")
-	}
+		buffer.WriteString(Escape(b.config, filter.Field))
 
-	b.buildValueList(buffer, values)
+		if filter.Type == rel.FilterInOp {
+			buffer.WriteString(" IN ")
+		} else {
+			buffer.WriteString(" NOT IN ")
+		}
+
+		b.buildValueList(buffer, values)
+	}
 }
 
 func (b *Builder) ph() string {

--- a/adapter/sql/builder_test.go
+++ b/adapter/sql/builder_test.go
@@ -1172,6 +1172,11 @@ func TestBuilder_Filter(t *testing.T) {
 			where.In("field", "value1", "value2", "value3"),
 		},
 		{
+			"1=0",
+			nil,
+			where.In("field", []interface{}{}...),
+		},
+		{
 			"`field` NOT IN (?)",
 			[]interface{}{"value1"},
 			where.Nin("field", "value1"),
@@ -1185,6 +1190,11 @@ func TestBuilder_Filter(t *testing.T) {
 			"`field` NOT IN (?,?,?)",
 			[]interface{}{"value1", "value2", "value3"},
 			where.Nin("field", "value1", "value2", "value3"),
+		},
+		{
+			"1=1",
+			nil,
+			where.Nin("field", []interface{}{}...),
 		},
 		{
 			"`field` LIKE ?",


### PR DESCRIPTION
In MySQL, `IN` clause with empty values causes a syntax error.
This PR replaces an empty-valued `IN` clause with `1=0` (or `1=1` for a `NOT IN` clause).

see
- https://github.com/typeorm/typeorm/issues/2195
- https://github.com/typeorm/typeorm/pull/6887