### PR TITLE
fix typo in comments

### DIFF
--- a/filter_query.go
+++ b/filter_query.go
@@ -333,7 +333,7 @@ func And(inner ...FilterQuery) FilterQuery {
 	}
 }
 
-// Or compares other filters using and.
+// Or compares other filters using or.
 func Or(inner ...FilterQuery) FilterQuery {
 	if len(inner) == 1 {
 		return inner[0]

--- a/where/where.go
+++ b/where/where.go
@@ -9,7 +9,7 @@ var (
 	// And compares other filters using and.
 	And = rel.And
 
-	// Or compares other filters using and.
+	// Or compares other filters using or.
 	Or = rel.Or
 
 	// Not wraps filters using not.


### PR DESCRIPTION
I stubled across these typos/errors while reading the documentation: https://go-rel.github.io/reference/where/

Possibly needs to be fixed in other places, depending on how the docs are created.