### PR TITLE
Fix Structset to handle uuid ([16]byte) correctly

### DIFF
--- a/structset_test.go
+++ b/structset_test.go
@@ -217,3 +217,22 @@ func TestStructset_differentStructMissingField(t *testing.T) {
 		Apply(doc, NewStructset(&user, true))
 	})
 }
+
+func TestStructset_uuid(t *testing.T) {
+	// package like https://github.com/google/uuid use [16]byte to represent uuid
+	var (
+		uuid   = [16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+		record = struct {
+			UUID [16]byte `db:",primary"`
+		}{UUID: uuid}
+		doc      = NewDocument(&record)
+		mutation = Mutation{
+			Cascade: true,
+			Mutates: map[string]Mutate{
+				"uuid": Set("uuid", uuid),
+			},
+		}
+	)
+
+	assert.Equal(t, mutation, Apply(doc, NewStructset(&record, false)))
+}

--- a/util.go
+++ b/util.go
@@ -106,7 +106,7 @@ func isDeepZero(rv reflect.Value, depth int) bool {
 	case reflect.Array:
 		// check one level deeper if it's an uuid ([16]byte)
 		if depth == 0 && rv.Type().Elem().Kind() == reflect.Uint8 && rv.Len() == 16 {
-			depth = 1
+			depth += 1
 		}
 
 		for i := 0; i < rv.Len(); i++ {

--- a/util.go
+++ b/util.go
@@ -104,6 +104,11 @@ func isDeepZero(rv reflect.Value, depth int) bool {
 		c := rv.Complex()
 		return math.Float64bits(real(c)) == 0 && math.Float64bits(imag(c)) == 0
 	case reflect.Array:
+		// check one level deeper if it's an uuid (ex: [16]byte)
+		if depth == 0 && rv.Type().Elem().Kind() == reflect.Uint8 {
+			depth = 1
+		}
+
 		for i := 0; i < rv.Len(); i++ {
 			if !isDeepZero(rv.Index(i), depth-1) {
 				return false

--- a/util.go
+++ b/util.go
@@ -104,8 +104,8 @@ func isDeepZero(rv reflect.Value, depth int) bool {
 		c := rv.Complex()
 		return math.Float64bits(real(c)) == 0 && math.Float64bits(imag(c)) == 0
 	case reflect.Array:
-		// check one level deeper if it's an uuid (ex: [16]byte)
-		if depth == 0 && rv.Type().Elem().Kind() == reflect.Uint8 {
+		// check one level deeper if it's an uuid ([16]byte)
+		if depth == 0 && rv.Type().Elem().Kind() == reflect.Uint8 && rv.Len() == 16 {
 			depth = 1
 		}
 

--- a/util.go
+++ b/util.go
@@ -105,7 +105,7 @@ func isDeepZero(rv reflect.Value, depth int) bool {
 		return math.Float64bits(real(c)) == 0 && math.Float64bits(imag(c)) == 0
 	case reflect.Array:
 		// check one level deeper if it's an uuid ([16]byte)
-		if depth == 0 && rv.Type().Elem().Kind() == reflect.Uint8 && rv.Len() == 16 {
+		if rv.Type().Elem().Kind() == reflect.Uint8 && rv.Len() == 16 {
 			depth += 1
 		}
 


### PR DESCRIPTION
Fixes https://github.com/go-rel/rel/issues/252:
- UUID package like https://github.com/google/uuid use [16] byte as underlying type
- Fix `isZero()` to handle byte array as if it were on the same depth