### PR TITLE
Support embeddable structs

### DIFF
--- a/association.go
+++ b/association.go
@@ -3,6 +3,7 @@ package rel
 import (
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/serenize/snaker"
@@ -187,12 +188,12 @@ func newAssociation(rv reflect.Value, index []int) Association {
 
 // Encode index slice into single string
 func encodeIndices(indices []int) string {
-	var out = ""
+	var sb strings.Builder
 	for _, index := range indices {
-		out += "/"
-		out += strconv.Itoa(index)
+		sb.WriteString("/")
+		sb.WriteString(strconv.Itoa(index))
 	}
-	return out
+	return sb.String()
 }
 
 func extractAssociationData(rt reflect.Type, index []int) associationData {

--- a/association.go
+++ b/association.go
@@ -1,8 +1,8 @@
 package rel
 
 import (
-	"fmt"
 	"reflect"
+	"strconv"
 	"sync"
 
 	"github.com/serenize/snaker"
@@ -185,11 +185,21 @@ func newAssociation(rv reflect.Value, index []int) Association {
 	}
 }
 
+// Encode index slice into single string
+func encodeIndices(indices []int) string {
+	var out = ""
+	for _, index := range indices {
+		out += "/"
+		out += strconv.Itoa(index)
+	}
+	return out
+}
+
 func extractAssociationData(rt reflect.Type, index []int) associationData {
 	var (
 		key = associationKey{
 			rt:    rt,
-			index: fmt.Sprint(index),
+			index: encodeIndices(index),
 		}
 	)
 
@@ -202,7 +212,7 @@ func extractAssociationData(rt reflect.Type, index []int) associationData {
 		ft        = sf.Type
 		ref       = sf.Tag.Get("ref")
 		fk        = sf.Tag.Get("fk")
-		fName     = fieldName(sf)
+		fName, _  = fieldName(sf)
 		assocData = associationData{
 			targetIndex: sf.Index,
 			through:     sf.Tag.Get("through"),

--- a/association_test.go
+++ b/association_test.go
@@ -121,7 +121,7 @@ func TestAssociation_Document(t *testing.T) {
 			var (
 				rv          = reflect.ValueOf(test.data)
 				sf, _       = rv.Type().Elem().FieldByName(test.field)
-				assoc       = newAssociation(rv, sf.Index[0])
+				assoc       = newAssociation(rv, sf.Index)
 				doc, loaded = assoc.Document()
 			)
 
@@ -269,7 +269,7 @@ func TestAssociation_Collection(t *testing.T) {
 			var (
 				rv          = reflect.ValueOf(test.data)
 				sf, _       = rv.Type().Elem().FieldByName(test.field)
-				assoc       = newAssociation(rv, sf.Index[0])
+				assoc       = newAssociation(rv, sf.Index)
 				col, loaded = assoc.Collection()
 			)
 

--- a/collection.go
+++ b/collection.go
@@ -79,7 +79,7 @@ func (c Collection) PrimaryValues() []interface{} {
 
 			for j := 0; j < idxLen; j++ {
 				if item := c.rvIndex(j); item.IsValid() {
-					values = append(values, item.Field(index[i]).Interface())
+					values = append(values, item.FieldByIndex(index[i]).Interface())
 				}
 			}
 

--- a/collection.go
+++ b/collection.go
@@ -79,7 +79,7 @@ func (c Collection) PrimaryValues() []interface{} {
 
 			for j := 0; j < idxLen; j++ {
 				if item := c.rvIndex(j); item.IsValid() {
-					values = append(values, item.FieldByIndex(index[i]).Interface())
+					values = append(values, reflectValueFieldByIndex(item, index[i], false).Interface())
 				}
 			}
 

--- a/document.go
+++ b/document.go
@@ -336,16 +336,14 @@ func (d Document) fieldByIndex(index []int) reflect.Value {
 }
 
 // Adds a prefix to field names
-func prefixFieldNames(fieldNames []string, prefix string) []string {
+func appendWithPrefix(target, fieldNames []string, prefix string) []string {
 	if prefix == "" {
-		return fieldNames
+		return append(target, fieldNames...)
 	}
-	// this copy is necessary as embedded structs can be reused
-	newNames := make([]string, len(fieldNames))
-	for i, name := range fieldNames {
-		newNames[i] = prefix + name
+	for _, name := range fieldNames {
+		target = append(target, prefix+name)
 	}
-	return newNames
+	return target
 }
 
 // Adds a field index and checks for conflicts
@@ -361,18 +359,15 @@ func (d *documentData) mergeEmbedded(other documentData, indexPrefix int, namePr
 	for name, path := range other.index {
 		d.addFieldIndex(namePrefix+name, append([]int{indexPrefix}, path...))
 	}
-	appendWithPrefix := func(slice, newNames []string) []string {
-		return append(slice, prefixFieldNames(newNames, namePrefix)...)
-	}
-	d.fields = appendWithPrefix(d.fields, other.fields)
-	d.belongsTo = appendWithPrefix(d.belongsTo, other.belongsTo)
-	d.hasOne = appendWithPrefix(d.hasOne, other.hasOne)
-	d.hasMany = appendWithPrefix(d.hasMany, other.hasMany)
-	d.primaryField = appendWithPrefix(d.primaryField, other.primaryField)
+	d.fields = appendWithPrefix(d.fields, other.fields, namePrefix)
+	d.belongsTo = appendWithPrefix(d.belongsTo, other.belongsTo, namePrefix)
+	d.hasOne = appendWithPrefix(d.hasOne, other.hasOne, namePrefix)
+	d.hasMany = appendWithPrefix(d.hasMany, other.hasMany, namePrefix)
+	d.primaryField = appendWithPrefix(d.primaryField, other.primaryField, namePrefix)
 	for index := range other.primaryIndex {
 		d.primaryIndex = append(d.primaryIndex, append([]int{indexPrefix}, index))
 	}
-	d.preload = appendWithPrefix(d.preload, other.preload)
+	d.preload = appendWithPrefix(d.preload, other.preload, namePrefix)
 	d.flag |= other.flag
 }
 

--- a/document.go
+++ b/document.go
@@ -184,10 +184,10 @@ func (d Document) Type(field string) (reflect.Type, bool) {
 // Value returns value of given field. if field does not exist, second returns value will be false.
 func (d Document) Value(field string) (interface{}, bool) {
 	if i, ok := d.data.index[field]; ok {
-		fv := reflectValueFieldByIndex(d.rv, i, false)
 
 		var (
 			value interface{}
+			fv    = reflectValueFieldByIndex(d.rv, i, false)
 			ft    = fv.Type()
 		)
 

--- a/document.go
+++ b/document.go
@@ -242,34 +242,6 @@ func (d Document) SetValue(field string, value interface{}) bool {
 	return false
 }
 
-func setPointerValue(ft reflect.Type, fv reflect.Value, rt reflect.Type, rv reflect.Value) bool {
-	if ft.Elem() != rt && !rt.AssignableTo(ft.Elem()) {
-		return false
-	}
-
-	if fv.IsNil() {
-		fv.Set(reflect.New(ft.Elem()))
-	}
-	fv.Elem().Set(rv)
-
-	return true
-}
-
-func setConvertValue(ft reflect.Type, fv reflect.Value, rt reflect.Type, rv reflect.Value) bool {
-	var (
-		rk = rt.Kind()
-		fk = ft.Kind()
-	)
-
-	// prevents unintentional conversion
-	if (rk >= reflect.Int || rk <= reflect.Uint64) && fk == reflect.String {
-		return false
-	}
-
-	fv.Set(rv.Convert(ft))
-	return true
-}
-
 // Init pointers to embedded structs for index path
 func initPointersForIndices(rv reflect.Value, indices []int) {
 	for depth := 0; depth < len(indices)-1; depth += 1 {

--- a/document_test.go
+++ b/document_test.go
@@ -329,6 +329,39 @@ func TestDocument_Value(t *testing.T) {
 	})
 }
 
+func TestDocument_ValueEmbedded(t *testing.T) {
+	type Embedded struct {
+		ID int
+	}
+	var (
+		record = struct {
+			*Embedded
+			Name string
+		}{}
+		doc = NewDocument(&record)
+	)
+
+	value, ok := doc.Value("id")
+	assert.True(t, ok)
+	assert.Nil(t, value)
+
+	value = doc.PrimaryValue()
+	assert.Nil(t, value)
+
+	doc.SetValue("id", 1)
+
+	value, ok = doc.Value("id")
+	assert.True(t, ok)
+	assert.Equal(t, 1, value)
+
+	value = doc.PrimaryValue()
+	assert.Equal(t, 1, value)
+
+	value, ok = doc.Value("name")
+	assert.True(t, ok)
+	assert.Equal(t, "", value)
+}
+
 func TestDocument_SetValue(t *testing.T) {
 	var (
 		record struct {

--- a/document_test.go
+++ b/document_test.go
@@ -192,11 +192,37 @@ func TestDocument_Index(t *testing.T) {
 			E []*float64 `db:"-"`
 		}{}
 		doc   = NewDocument(&record)
-		index = map[string]int{
-			"a": 0,
-			"b": 1,
-			"c": 2,
-			"D": 3,
+		index = map[string][]int{
+			"a": {0},
+			"b": {1},
+			"c": {2},
+			"D": {3},
+		}
+	)
+
+	assert.Equal(t, index, doc.Index())
+}
+
+func TestDocument_IndexNested(t *testing.T) {
+	type firstEmbedded struct {
+		A int
+		B int
+	}
+	type secondEmbedded struct {
+		D float32
+	}
+	var (
+		record = struct {
+			firstEmbedded
+			C string
+			secondEmbedded
+		}{}
+		doc   = NewDocument(&record)
+		index = map[string][]int{
+			"a": {0, 0},
+			"b": {0, 1},
+			"c": {1},
+			"d": {2, 0},
 		}
 	)
 

--- a/util.go
+++ b/util.go
@@ -197,9 +197,6 @@ func reflectValueFieldByIndex(rv reflect.Value, index []int, init bool) reflect.
 	if len(index) == 1 {
 		return rv.Field(index[0])
 	}
-	if rv.Kind() != reflect.Struct {
-		panic("rel: value must be a struct")
-	}
 
 	for depth := 0; depth < len(index)-1; depth += 1 {
 		field := rv.Field(index[depth])

--- a/util.go
+++ b/util.go
@@ -133,6 +133,34 @@ func isDeepZero(rv reflect.Value, depth int) bool {
 	}
 }
 
+func setPointerValue(ft reflect.Type, fv reflect.Value, rt reflect.Type, rv reflect.Value) bool {
+	if ft.Elem() != rt && !rt.AssignableTo(ft.Elem()) {
+		return false
+	}
+
+	if fv.IsNil() {
+		fv.Set(reflect.New(ft.Elem()))
+	}
+	fv.Elem().Set(rv)
+
+	return true
+}
+
+func setConvertValue(ft reflect.Type, fv reflect.Value, rt reflect.Type, rv reflect.Value) bool {
+	var (
+		rk = rt.Kind()
+		fk = ft.Kind()
+	)
+
+	// prevents unintentional conversion
+	if (rk >= reflect.Int || rk <= reflect.Uint64) && fk == reflect.String {
+		return false
+	}
+
+	fv.Set(rv.Convert(ft))
+	return true
+}
+
 func fmtiface(v interface{}) string {
 	if str, ok := v.(string); ok {
 		return "\"" + str + "\""

--- a/util.go
+++ b/util.go
@@ -193,6 +193,7 @@ func encodeIndices(indices []int) string {
 }
 
 // Get field by index and init pointers on path if flag is true
+//  modified from: https://cs.opensource.google/go/go/+/refs/tags/go1.17.7:src/reflect/value.go;l=1228-1245;bpv
 func reflectValueFieldByIndex(rv reflect.Value, index []int, init bool) reflect.Value {
 	if len(index) == 1 {
 		return rv.Field(index[0])


### PR DESCRIPTION
Hi! I've added support for embedded structs [as discussed in this issue](https://github.com/go-rel/rel/issues/241).

Both pointers and plain fields are supported.
```go
type Person struct {
	ID   int
	Name string
}

type Employee struct {
	Person
	Salary int
}
```

By default embedded field names are added without prefixes. Name prefixes can be set like for other fields:
```go
type Employee struct {
	Person   `db:"person_"`
	Salary int
}
```

If two fields have the same name, REL panics during construction:

### What I've changed

* `documentData` indices now store full field paths as []int
* `documentData`s are merged for embedded fields during creation
* Embedded pointers are initialized during document creation

### Tests

I've added tests for all main cases
