### PR TITLE
Add support for scanning embedded assoc

### DIFF
--- a/association.go
+++ b/association.go
@@ -64,7 +64,7 @@ func (a Association) LazyDocument() (*Document, bool) {
 	return a.document(true)
 }
 
-func (a Association) document(lazy bool) (*Document, bool) {
+func (a *Association) document(lazy bool) (*Document, bool) {
 	if a.doc != nil {
 		return a.doc, a.doc.Persisted()
 	}

--- a/association.go
+++ b/association.go
@@ -43,6 +43,7 @@ var associationCache sync.Map
 type Association struct {
 	data associationData
 	rv   reflect.Value
+	doc  *Document
 }
 
 // Type of association.
@@ -64,6 +65,10 @@ func (a Association) LazyDocument() (*Document, bool) {
 }
 
 func (a Association) document(lazy bool) (*Document, bool) {
+	if a.doc != nil {
+		return a.doc, a.doc.Persisted()
+	}
+
 	var (
 		rv = reflectValueFieldByIndex(a.rv, a.data.targetIndex, !lazy)
 	)
@@ -78,17 +83,11 @@ func (a Association) document(lazy bool) (*Document, bool) {
 			return NewDocument(rv), false
 		}
 
-		var (
-			doc = NewDocument(rv)
-		)
-
-		return doc, doc.Persisted()
+		a.doc = NewDocument(rv)
+		return a.doc, a.doc.Persisted()
 	default:
-		var (
-			doc = NewDocument(rv.Addr())
-		)
-
-		return doc, doc.Persisted()
+		a.doc = NewDocument(rv.Addr())
+		return a.doc, a.doc.Persisted()
 	}
 }
 

--- a/document_test.go
+++ b/document_test.go
@@ -474,6 +474,54 @@ func TestDocument_Scanners(t *testing.T) {
 	assert.Equal(t, scanners, doc.Scanners(fields))
 }
 
+func TestDocument_Scanners_withAssoc(t *testing.T) {
+	var (
+		record = Transaction{
+			ID:      1,
+			BuyerID: 2,
+			Status:  "SENT",
+			Buyer: User{
+				ID:   2,
+				Name: "user",
+				WorkAddress: &Address{
+					Street: "Takeshita-dori",
+				},
+			},
+		}
+		doc      = NewDocument(&record)
+		fields   = []string{"id", "user_id", "buyer.id", "buyer.name", "buyer.work_address.street", "status"}
+		scanners = []interface{}{
+			Nullable(&record.ID),
+			Nullable(&record.BuyerID),
+			Nullable(&record.Buyer.ID),
+			Nullable(&record.Buyer.Name),
+			Nullable(&record.Buyer.WorkAddress.Street),
+			Nullable(&record.Status),
+		}
+	)
+
+	assert.Equal(t, scanners, doc.Scanners(fields))
+}
+
+func TestDocument_Scanners_withUnitializedAssoc(t *testing.T) {
+	var (
+		record   = Transaction{}
+		doc      = NewDocument(&record)
+		fields   = []string{"id", "user_id", "buyer.id", "buyer.name", "status", "buyer.work_address.street"}
+		result   = doc.Scanners(fields)
+		expected = []interface{}{
+			Nullable(&record.ID),
+			Nullable(&record.BuyerID),
+			Nullable(&record.Buyer.ID),
+			Nullable(&record.Buyer.Name),
+			Nullable(&record.Status),
+			Nullable(&record.Buyer.WorkAddress.Street),
+		}
+	)
+
+	assert.Equal(t, expected, result)
+}
+
 func TestDocument_ScannersInitPointers(t *testing.T) {
 	type Embedded1 struct {
 		ID int


### PR DESCRIPTION
Scan query result to embedded has one or belongs to association when the returned query result have field path to the association (example: "assoc_name.field_name")

example: 

```
var users []Users
err := repo.FindAll(ctx, &users, rel.Select("*", "follower_stats.followers_count").Join("follower_stats").Where(where.Gt("follower_stats.followers_count", 100)))
```

related: https://github.com/go-rel/rel/issues/287