### PR TITLE
`Do` takes a context as its first argument

### DIFF
--- a/migrator/migrator.go
+++ b/migrator/migrator.go
@@ -160,7 +160,7 @@ func (m *Migrator) run(ctx context.Context, migrations []rel.Migration) {
 	adapter := m.repo.Adapter(ctx)
 	for _, migration := range migrations {
 		if fn, ok := migration.(rel.Do); ok {
-			check(fn(m.repo))
+			check(fn(ctx, m.repo))
 		} else {
 			check(adapter.Apply(ctx, migration))
 		}

--- a/schema.go
+++ b/schema.go
@@ -1,6 +1,9 @@
 package rel
 
-import "strings"
+import (
+	"context"
+	"strings"
+)
 
 // SchemaOp type.
 type SchemaOp uint8
@@ -138,7 +141,7 @@ func (r Raw) internalMigration()       {}
 func (r Raw) internalTableDefinition() {}
 
 // Do used internally for schema migration.
-type Do func(Repository) error
+type Do func(context.Context, Repository) error
 
 func (d Do) description() string {
 	return "run go code"

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,6 +1,7 @@
 package rel
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -221,7 +222,7 @@ func TestDo(t *testing.T) {
 		schema Schema
 	)
 
-	schema.Do(func(repo Repository) error { return nil })
+	schema.Do(func(ctx context.Context, repo Repository) error { return nil })
 	assert.NotNil(t, schema.Migrations[0])
 }
 


### PR DESCRIPTION
related: https://github.com/go-rel/migration/issues/9

Currently, `Do` cannot run under the transaction scope of a migration, so it cannot access schemas that have been updated by other migrations.

To solve this, allow the context to be passed as the first argument of `Do`.