### PR TITLE
Extend adapter interface with Name function

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -6,6 +6,7 @@ import (
 
 // Adapter interface
 type Adapter interface {
+	DBType() string
 	Close() error
 
 	Instrumentation(instrumenter Instrumenter)

--- a/adapter.go
+++ b/adapter.go
@@ -6,7 +6,7 @@ import (
 
 // Adapter interface
 type Adapter interface {
-	DBType() string
+	Name() string
 	Close() error
 
 	Instrumentation(instrumenter Instrumenter)

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -91,7 +91,7 @@ func (ta *testAdapter) Exec(ctx context.Context, stmt string, args []any) (int64
 	return int64(mockArgs.Int(0)), int64(mockArgs.Int(1)), mockArgs.Error(2)
 }
 
-func (ta *testAdapter) DBType() string {
+func (ta *testAdapter) Name() string {
 	args := ta.Called()
 	return args.String(0)
 }

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -90,3 +90,8 @@ func (ta *testAdapter) Exec(ctx context.Context, stmt string, args []any) (int64
 	mockArgs := ta.Called(ctx, stmt, args)
 	return int64(mockArgs.Int(0)), int64(mockArgs.Int(1)), mockArgs.Error(2)
 }
+
+func (ta *testAdapter) DBType() string {
+	args := ta.Called()
+	return args.String(0)
+}

--- a/repository_test.go
+++ b/repository_test.go
@@ -47,9 +47,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestRepository_Instrumentation(t *testing.T) {
-	var (
-		repo = repository{rootAdapter: &testAdapter{}}
-	)
+	repo := repository{rootAdapter: &testAdapter{}}
 
 	assert.Nil(t, repo.instrumenter)
 	assert.NotPanics(t, func() {
@@ -72,6 +70,18 @@ func TestRepository_Ping(t *testing.T) {
 	adapter.On("Ping").Return(nil).Once()
 
 	assert.Nil(t, repo.Ping(context.TODO()))
+	adapter.AssertExpectations(t)
+}
+
+func TestRepository_AdapterName(t *testing.T) {
+	var (
+		adapter = &testAdapter{}
+		repo    = New(adapter)
+	)
+
+	adapter.On("Name").Return("test").Once()
+
+	assert.Equal(t, "test", repo.Adapter(context.TODO()).Name())
 	adapter.AssertExpectations(t)
 }
 


### PR DESCRIPTION
Refs #345 

~~I went with `DBType` name as this is also what for example xorm uses and it's more descriptive~~