### PR TITLE
Allow multimple selects

### DIFF
--- a/query.go
+++ b/query.go
@@ -142,7 +142,7 @@ func (q *Query) AddPopulator(populator QueryPopulator) {
 
 // Select filter fields to be selected from database.
 func (q Query) Select(fields ...string) Query {
-	q.SelectQuery = NewSelect(fields...)
+	q.SelectQuery.Fields = append(q.SelectQuery.Fields, fields...)
 	return q
 }
 


### PR DESCRIPTION
This change would allow for multiple selects.

For example:
```go
var query = rel.Select("id", "title").From("pools")

if includeAvgScore {
    query.Select("avg_score AS score")
} else {
    query.Select("score")
}
```