### PR TITLE
fix data conflict when prepending preloads from document meta

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -1201,7 +1201,13 @@ func (r repository) withDefaultScope(meta DocumentMeta, query Query, preload boo
 	}
 
 	if preload && bool(query.CascadeQuery) {
-		query.PreloadQuery = append(meta.preload, query.PreloadQuery...)
+		// Clone meta.preload to avoid data race
+		//
+		// The implementation for cloning a slice is the same as `slices.Clone` in go 1.23
+		// https://cs.opensource.google/go/go/+/refs/tags/go1.23.3:src/slices/slices.go;l=350
+		metaPreload := append(meta.preload[:0:0], meta.preload...)
+
+		query.PreloadQuery = append(metaPreload, query.PreloadQuery...)
 	}
 
 	return query


### PR DESCRIPTION
Fix data race due to the concurrent access of shared slice by multiple goroutines.

https://github.com/go-rel/rel/blob/6c3495d2f4128b45e5d576ee72d6f715eb0b19cc/repository.go#L1204

The above code prepends `meta.preload` to `query.PreloadQuery`. However:
 
- If the underlying array (`meta.preload`'s capacity) has enough space, the new slice still references the same underlying array.
- When multiple goroutines prepend to `query.PreloadQuery` concurrently, they might end up using the same underlying array, leading to:
  - Overwriting of values by different goroutines.
  - Inconsistent results in `query.PreloadQuery`, as one goroutine's operation interferes with another's.
  - https://go.dev/play/p/ulUQgeS6EBa

To fix this, clone `meta.preload` and use it for prepending.

[Reproduction example](https://gist.github.com/youpy/c332cf221477183ff76350662fb7681b)